### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ volumes:
 
 services:
   nexus:
-    build: ./docker-nexus3
+    build: ./nexus
     restart: always
     ports:
       - "18081:8081"


### PR DESCRIPTION
Seems the path to the nexus build was changed, but overlooked here. This should fix the issue where the Dockerfile couldn't be found for the nexus service build stage.